### PR TITLE
Add anchor links with AnchorJS

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,8 +6,12 @@
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="description" content="{{ site.description }}">
 
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/anchor-js/0.3.1/anchor.min.css">
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+
+    <script src="//cdnjs.cloudflare.com/ajax/libs/anchor-js/0.3.1/anchor.min.js"></script>
+    <script src="{{ "/js/main.js" | prepend: site.baseurl }}"></script>
 
     {% include analytics.html %}
 </head>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,3 @@
+document.addEventListener("DOMContentLoaded", function (event) {
+  addAnchors();
+});


### PR DESCRIPTION
Kramdown (the Markdown engine we're using with Jekyll) automatically generates ids on heading tags so you can link to specific sections of a page. However, there is currently no way for the user to get a link to the specific heading besides looking at the id or knowing what the generated id would be and then modifying the page's URL.

With AnchorJS, you can hover over a heading and an achor icon will appear. You can click on it to jump to that section, which also means you can give your current URL to someone else so they can see that specific section of the document (see the [AnchorJS demo](http://bryanbraun.github.io/anchorjs/)).
