### PR TITLE
update mentors based on activity

### DIFF
--- a/pages/people.md
+++ b/pages/people.md
@@ -9,12 +9,8 @@ Without the support of these amazing people, Pair Columbus would not be possible
 __Mentors:__
 
 ### Matt DeGoey
-- degoeym@gmail.com
 - @degoeym
-
-### Jennifer Cable
-- jkcable@yahoo.com
-- @jkcable
+- degoeym@gmail.com
 
 ### Michael Gee
 - @mikegee
@@ -32,12 +28,12 @@ __Mentors:__
 - @nicolasmccurdy
 - thenickperson@gmail.com
 
-### Tirthankar Bhattacharjee
-- @theidlemonk
-
 ### Jay Bobo
 - @jaybobo
-- jbobo@goodproduce.net
+- info@paircolumbus.org
 
-### Joshua Hamilton
-- @VariousWeapon
+### Travis Sperry
+- @TravisSperry
+
+### Joe Reich
+- @sjreich


### PR DESCRIPTION
Modifies people list to reflect mentors based on their perceived activity and contributions to the community. 
- Mentors - Regular attendees with development experience that actively contribute through talks, code reviews, assisting with event setup, challenge/app creation, etc
- Contributors - Create one-off challenges, make bugfixes, add functionality (ie pairs app).

Thoughts? I'd really like to find a way to incentivize mentorship and contribution beyond listing people on this page.
